### PR TITLE
Empty vals in args array causes double spaces in node spawn arguments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ module.exports = exports = function(opts) {
         if (!exit) {
           return setTimeout(waitingForGo, 1);
         } else {
+          opts.debug && console.log("Compass CSS From Cache");
           return next();
         }
       }


### PR DESCRIPTION
Empty vals in args array causes double spaces in node spawn arguments.
This caused spawn process to not read the arguments right.

Tested with NodeJS v0.10.1
